### PR TITLE
[feat] DB 연결 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.env
 node_modules

--- a/app.js
+++ b/app.js
@@ -1,5 +1,7 @@
 import express from 'express';
+import dotenv from 'dotenv';
 import path from 'path';
+import mysql from 'mysql2';
 
 import * as auth from './routes/auth.js';
 import * as question from './routes/question.js';
@@ -8,6 +10,25 @@ import * as answer from './routes/answer.js';
 import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+dotenv.config();
+
+const dataBase = mysql.createConnection({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    database: process.env.DB_NAME
+});
+
+dataBase.connect(function (err) {
+    if (err) {
+        console.error('mysql connection error');
+        console.error(err);
+        throw err;
+    } else {
+        console.log("DB connection created!");
+    }
+});
 
 const app = express();
 const port = 3000;
@@ -30,3 +51,5 @@ app.get('/', (req, res) => {
     //res.render('index');
     res.send('Hello World!')
 });
+
+export default dataBase;


### PR DESCRIPTION
## 📝 PR 요약
🪵 작업 브랜치
- chore/#6-db-connect
## 🔧 작업 내용
- 로컬에 mysql을 설치
  [설치 가이드 참고 (Mac)](https://velog.io/@mingle_1017/Mysql-%EC%84%A4%EC%B9%98-%EB%B0%8F-%ED%85%8C%EC%9D%B4%EB%B8%94-%EC%83%9D%EC%84%B1%ED%95%98%EA%B8%B0%EB%A7%A5%EB%B6%81-%EB%B2%84%EC%A0%84)
- mysql에 유저 추가
  [추가 방법 참고](https://technote.kr/32)
- WorkBench, DataGrip 등의 DBMS 연결
- `app.js`에서 DB 연결 설정
  이 때, DB 연결에 필요한 정보는 `.env`로 뺐다.
## ❗ 참고 사항
`dotenv`와 `mysql2` 모듈 설치가 필요하다.
```bash
npm install dotenv mysql2
```
그러나 어차피 추후 업로드 할 `package.json`에 관련 정보가 포함되어 있으므로 굳이 따로 설치할 필요는 없다. (`npm install`만 해도 된다)
## 💡 이슈
- close #6